### PR TITLE
unignore bulk test (except JVM)

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -32,19 +32,22 @@ jgitver {
 kotlin {
   jvmToolchain(21)
   explicitApiWarning()
-  compilerOptions { allWarningsAsErrors = true }
+  compilerOptions {
+    allWarningsAsErrors = true
+    freeCompilerArgs.addAll("-Xexpect-actual-classes", "-Xconsistent-data-class-copy-visibility")
+  }
 
   jvm()
 
   js(IR) {
-    browser()
-    nodejs()
+    browser { testTask { useMocha { timeout = "10min" } } }
+    nodejs { testTask { useMocha { timeout = "10min" } } }
   }
 
   wasmJs {
-    browser()
-    nodejs()
-    d8 {}
+    browser { testTask { useMocha { timeout = "10min" } } }
+    nodejs { testTask { useMocha { timeout = "10min" } } }
+    d8 { testTask { useMocha { timeout = "10min" } } }
   }
 
   // native tier 1

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -45,9 +45,9 @@ kotlin {
   }
 
   wasmJs {
-    browser { testTask { useMocha { timeout = "10min" } } }
-    nodejs { testTask { useMocha { timeout = "10min" } } }
-    d8 { testTask { useMocha { timeout = "10min" } } }
+    browser()
+    nodejs()
+    d8()
   }
 
   // native tier 1

--- a/karma.config.d/config.js
+++ b/karma.config.d/config.js
@@ -1,0 +1,9 @@
+// noinspection JSUnresolvedReference
+// https://youtrack.jetbrains.com/issue/KT-73191/
+config.set({
+  client: {
+    mocha: {
+      timeout: "10min"
+    }
+  }
+});

--- a/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/BulkTest.kt
+++ b/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/BulkTest.kt
@@ -2,12 +2,10 @@ package co.pokeapi.pokekotlin.test
 
 import co.pokeapi.pokekotlin.model.ResourceSummary
 import co.pokeapi.pokekotlin.model.ResourceSummaryList
-import kotlin.test.Ignore
 import kotlin.test.Test
 import kotlin.test.fail
 import kotlinx.coroutines.test.runTest
 
-@Ignore
 class BulkTest {
 
   private suspend fun testCase(cat: String, id: Int, getObject: suspend (Int) -> Any) {

--- a/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/BulkTest.kt
+++ b/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/BulkTest.kt
@@ -6,6 +6,7 @@ import kotlin.test.Test
 import kotlin.test.fail
 import kotlinx.coroutines.test.runTest
 
+@IgnoreOnJvm // Should work on JVM but it's OOMing.
 class BulkTest {
 
   private suspend fun testCase(cat: String, id: Int, getObject: suspend (Int) -> Any) {

--- a/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.kt
+++ b/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.kt
@@ -1,0 +1,6 @@
+package co.pokeapi.pokekotlin.test
+
+/** Stub annotation to act as a typealias destination for non-applied Ignores. */
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION) annotation class NoOpIgnore()
+
+@Target(AnnotationTarget.CLASS, AnnotationTarget.FUNCTION) expect annotation class IgnoreOnJvm()

--- a/src/jsTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.js.kt
+++ b/src/jsTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.js.kt
@@ -1,0 +1,3 @@
+package co.pokeapi.pokekotlin.test
+
+actual typealias IgnoreOnJvm = NoOpIgnore

--- a/src/jvmTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.jvm.kt
+++ b/src/jvmTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.jvm.kt
@@ -1,0 +1,3 @@
+package co.pokeapi.pokekotlin.test
+
+actual typealias IgnoreOnJvm = org.junit.Ignore

--- a/src/nativeTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.native.kt
+++ b/src/nativeTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.native.kt
@@ -1,0 +1,3 @@
+package co.pokeapi.pokekotlin.test
+
+actual typealias IgnoreOnJvm = NoOpIgnore

--- a/src/wasmJsTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.wasmJs.kt
+++ b/src/wasmJsTest/kotlin/co/pokeapi/pokekotlin/test/Ignore.wasmJs.kt
@@ -1,0 +1,3 @@
+package co.pokeapi.pokekotlin.test
+
+actual typealias IgnoreOnJvm = NoOpIgnore


### PR DESCRIPTION
- JVM: ooming, unsure why. ignoring on that platform
- JS: async tests are timing out. We can set the mocha timeout in the gradle dsl
- WASM: ditto, but we [can't](https://youtrack.jetbrains.com/issue/KT-73191/KJS-Gradle-Cant-set-browser-test-timeout-with-karma-DSL-from-KGP) set the timeout via gradle so we create a JS config instead.