### PR TITLE
Fixed typo in GenerationIiiTypeSprites

### DIFF
--- a/src/commonMain/kotlin/co/pokeapi/pokekotlin/model/pokemon.kt
+++ b/src/commonMain/kotlin/co/pokeapi/pokekotlin/model/pokemon.kt
@@ -1027,7 +1027,7 @@ public data class GenerationIiiTypeSprites(
   val colosseum: TypeSprites,
   val emerald: TypeSprites,
   @SerialName("firered-leafgreen") val fireredLeafgreen: TypeSprites,
-  @SerialName("ruby-saphire") val rubySaphire: TypeSprites,
+  @SerialName("ruby-sapphire") val rubySaphire: TypeSprites,
   val xd: TypeSprites,
 )
 


### PR DESCRIPTION
### Summary
As mentioned in #158 the serial name for type sprites for ruby and sapphire seem to have [changed in the API](https://github.com/PokeAPI/pokeapi/pull/1324), which leads to `getType()` throwing an exception.

### Changes
- The serial name was changed from `ruby-saphire` to `ruby-sapphire`

### Note
Running the tests everything succeeds, except for Pokemon bulk fetching. It appears that the new mega evolutions from Legends ZA are missing many fields, like `baseExperience`, which instead of a numeric value is `null`. Since this was not caused by my changes and is not within the scope of the issue I fixed I will not fix this test case with this PR.