### PR TITLE
add missing EvolutionDetail fields for regional-variant evolutions

### DIFF
--- a/src/commonMain/kotlin/co/pokeapi/pokekotlin/model/evolution.kt
+++ b/src/commonMain/kotlin/co/pokeapi/pokekotlin/model/evolution.kt
@@ -57,6 +57,9 @@ public data class ChainLink(
  * @param minHappiness The minimum required level of happiness of the evolving Pokémon species.
  * @param minBeauty The minimum required level of beauty of the evolving Pokémon species.
  * @param minAffection The minimum required level of affection of the evolving Pokémon species.
+ * @param minDamageTaken The minimum amount of damage taken during the evolution trigger event.
+ * @param minMoveCount The minimum number of times a move must be used for evolution to trigger.
+ * @param minSteps The minimum number of steps that must be taken for evolution to trigger.
  * @param partySpecies The Pokémon species that must be in the players party to trigger evolution.
  * @param partyType The player must have a Pokémon of this type in their party to trigger evolution.
  * @param relativePhysicalStats The required relation between the Pokémon's Attack and Defense
@@ -65,8 +68,19 @@ public data class ChainLink(
  * @param tradeSpecies Pokémon species for which this one must be traded.
  * @param needsOverworldRain Whether or not it must be raining in the overworld to trigger
  *   evolution.
+ * @param needsMultiplayer Whether or not multiplayer link play is needed to trigger evolution.
+ * @param nearSpecialRock Whether or not the evolving Pokémon species must be near a Moss Rock or
+ *   Icy Rock to trigger evolution.
  * @param turnUpsideDown Whether or not the 3DS needs to be turned upside-down as this Pokémon
  *   levels up.
+ * @param isDefault Whether this evolution is considered the expected evolution in a main series
+ *   game.
+ * @param baseForm The required form for the evolving Pokémon species for this evolution to occur.
+ * @param evolvedForm The form the resulting Pokémon species takes after this evolution.
+ * @param usedMove The move that must be used by the evolving Pokémon species during the evolution
+ *   trigger event.
+ * @param region The required region in which this evolution can occur.
+ * @param versionGroup The version group in which the evolution was introduced.
  */
 @Serializable
 @JsNonWasmExport
@@ -82,13 +96,24 @@ public data class EvolutionDetail(
   val minHappiness: Int? = null,
   val minBeauty: Int? = null,
   val minAffection: Int? = null,
+  val minDamageTaken: Int? = null,
+  val minMoveCount: Int? = null,
+  val minSteps: Int? = null,
   val partySpecies: Handle.Named<PokemonSpecies>? = null,
   val partyType: Handle.Named<Type>? = null,
   val relativePhysicalStats: Int? = null,
   val timeOfDay: String = "",
   val tradeSpecies: Handle.Named<PokemonSpecies>? = null,
   val needsOverworldRain: Boolean = false,
+  val needsMultiplayer: Boolean = false,
+  val nearSpecialRock: Boolean = false,
   val turnUpsideDown: Boolean = false,
+  val isDefault: Boolean = false,
+  val baseForm: Handle.Named<PokemonVariety>? = null,
+  val evolvedForm: Handle.Named<PokemonVariety>? = null,
+  val usedMove: Handle.Named<Move>? = null,
+  val region: Handle.Named<Region>? = null,
+  val versionGroup: Handle.Named<VersionGroup>? = null,
 )
 
 /**

--- a/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/model/EvolutionTest.kt
+++ b/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/model/EvolutionTest.kt
@@ -1,6 +1,8 @@
 package co.pokeapi.pokekotlin.test.model
 
+import co.pokeapi.pokekotlin.internal.PokeApiJson
 import co.pokeapi.pokekotlin.model.ChainLink
+import co.pokeapi.pokekotlin.model.EvolutionChain
 import co.pokeapi.pokekotlin.model.EvolutionDetail
 import co.pokeapi.pokekotlin.model.Handle
 import co.pokeapi.pokekotlin.model.Name
@@ -8,8 +10,128 @@ import co.pokeapi.pokekotlin.test.LocalPokeApi
 import kotlin.test.Test
 import kotlin.test.assertContains
 import kotlin.test.assertEquals
+import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlinx.coroutines.test.runTest
+
+// Real `/api/v2/evolution-chain/96` (Wooper) response fetched live from pokeapi.co. The pinned
+// api-data submodule predates the `region`/`base_form`/`version_group` fields this fixture
+// exercises, so this is embedded directly rather than served by the local test server.
+private val wooperEvolutionChainJson =
+  """
+  {
+      "baby_trigger_item": null,
+      "chain": {
+          "evolution_details": [],
+          "evolves_to": [
+              {
+                  "evolution_details": [
+                      {
+                          "base_form": null,
+                          "evolved_form": null,
+                          "gender": null,
+                          "held_item": null,
+                          "is_default": true,
+                          "item": null,
+                          "known_move": null,
+                          "known_move_type": null,
+                          "location": null,
+                          "min_affection": null,
+                          "min_beauty": null,
+                          "min_damage_taken": null,
+                          "min_happiness": null,
+                          "min_level": 20,
+                          "min_move_count": null,
+                          "min_steps": null,
+                          "near_special_rock": false,
+                          "needs_multiplayer": false,
+                          "needs_overworld_rain": false,
+                          "party_species": null,
+                          "party_type": null,
+                          "region": null,
+                          "relative_physical_stats": null,
+                          "time_of_day": "",
+                          "trade_species": null,
+                          "trigger": {
+                              "name": "level-up",
+                              "url": "/api/v2/evolution-trigger/1/"
+                          },
+                          "turn_upside_down": false,
+                          "used_move": null,
+                          "version_group": {
+                              "name": "gold-silver",
+                              "url": "/api/v2/version-group/3/"
+                          }
+                      }
+                  ],
+                  "evolves_to": [],
+                  "is_baby": false,
+                  "species": {
+                      "name": "quagsire",
+                      "url": "/api/v2/pokemon-species/195/"
+                  }
+              },
+              {
+                  "evolution_details": [
+                      {
+                          "base_form": {
+                              "name": "wooper-paldea",
+                              "url": "/api/v2/pokemon/10253/"
+                          },
+                          "evolved_form": null,
+                          "gender": null,
+                          "held_item": null,
+                          "is_default": true,
+                          "item": null,
+                          "known_move": null,
+                          "known_move_type": null,
+                          "location": null,
+                          "min_affection": null,
+                          "min_beauty": null,
+                          "min_damage_taken": null,
+                          "min_happiness": null,
+                          "min_level": 20,
+                          "min_move_count": null,
+                          "min_steps": null,
+                          "near_special_rock": false,
+                          "needs_multiplayer": false,
+                          "needs_overworld_rain": false,
+                          "party_species": null,
+                          "party_type": null,
+                          "region": null,
+                          "relative_physical_stats": null,
+                          "time_of_day": "",
+                          "trade_species": null,
+                          "trigger": {
+                              "name": "level-up",
+                              "url": "/api/v2/evolution-trigger/1/"
+                          },
+                          "turn_upside_down": false,
+                          "used_move": null,
+                          "version_group": {
+                              "name": "scarlet-violet",
+                              "url": "/api/v2/version-group/25/"
+                          }
+                      }
+                  ],
+                  "evolves_to": [],
+                  "is_baby": false,
+                  "species": {
+                      "name": "clodsire",
+                      "url": "/api/v2/pokemon-species/980/"
+                  }
+              }
+          ],
+          "is_baby": false,
+          "species": {
+              "name": "wooper",
+              "url": "/api/v2/pokemon-species/194/"
+          }
+      },
+      "id": 96
+  }
+  """
+    .trimIndent()
 
 class EvolutionTest {
 
@@ -273,6 +395,40 @@ class EvolutionTest {
       assertEquals(Handle.of(293, "full-incense"), babyTriggerItem)
       assertEquals(true, chain.isBaby)
     }
+  }
+
+  // Wooper (species 194, chain 96) evolves into Quagsire in most games but into the
+  // Paldean-exclusive Clodsire in Scarlet/Violet. The two are only distinguishable via
+  // `versionGroup`/`baseForm` - without those fields both branches decode to the exact same
+  // EvolutionDetail, silently discarding the distinction.
+  @Test
+  fun decodeEvolutionChainWooperRegionalVariant() {
+    val chain = PokeApiJson.decodeFromString<EvolutionChain>(wooperEvolutionChainJson)
+    val quagsireDetail =
+      chain.chain.evolvesTo.single { it.species.name == "quagsire" }.evolutionDetails.single()
+    val clodsireDetail =
+      chain.chain.evolvesTo.single { it.species.name == "clodsire" }.evolutionDetails.single()
+
+    assertEquals(
+      EvolutionDetail(
+        trigger = Handle.of(1, "level-up"),
+        minLevel = 20,
+        isDefault = true,
+        versionGroup = Handle.of(3, "gold-silver"),
+      ),
+      quagsireDetail,
+    )
+    assertEquals(
+      EvolutionDetail(
+        trigger = Handle.of(1, "level-up"),
+        minLevel = 20,
+        isDefault = true,
+        baseForm = Handle.of(10253, "wooper-paldea"),
+        versionGroup = Handle.of(25, "scarlet-violet"),
+      ),
+      clodsireDetail,
+    )
+    assertNotEquals(quagsireDetail, clodsireDetail)
   }
 
   @Test

--- a/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/model/EvolutionTest.kt
+++ b/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/model/EvolutionTest.kt
@@ -1,6 +1,6 @@
 package co.pokeapi.pokekotlin.test.model
 
-import co.pokeapi.pokekotlin.internal.PokeApiJson
+import co.pokeapi.pokekotlin.PokeApi
 import co.pokeapi.pokekotlin.model.ChainLink
 import co.pokeapi.pokekotlin.model.EvolutionChain
 import co.pokeapi.pokekotlin.model.EvolutionDetail
@@ -13,125 +13,6 @@ import kotlin.test.assertEquals
 import kotlin.test.assertNotEquals
 import kotlin.test.assertNotNull
 import kotlinx.coroutines.test.runTest
-
-// Real `/api/v2/evolution-chain/96` (Wooper) response fetched live from pokeapi.co. The pinned
-// api-data submodule predates the `region`/`base_form`/`version_group` fields this fixture
-// exercises, so this is embedded directly rather than served by the local test server.
-private val wooperEvolutionChainJson =
-  """
-  {
-      "baby_trigger_item": null,
-      "chain": {
-          "evolution_details": [],
-          "evolves_to": [
-              {
-                  "evolution_details": [
-                      {
-                          "base_form": null,
-                          "evolved_form": null,
-                          "gender": null,
-                          "held_item": null,
-                          "is_default": true,
-                          "item": null,
-                          "known_move": null,
-                          "known_move_type": null,
-                          "location": null,
-                          "min_affection": null,
-                          "min_beauty": null,
-                          "min_damage_taken": null,
-                          "min_happiness": null,
-                          "min_level": 20,
-                          "min_move_count": null,
-                          "min_steps": null,
-                          "near_special_rock": false,
-                          "needs_multiplayer": false,
-                          "needs_overworld_rain": false,
-                          "party_species": null,
-                          "party_type": null,
-                          "region": null,
-                          "relative_physical_stats": null,
-                          "time_of_day": "",
-                          "trade_species": null,
-                          "trigger": {
-                              "name": "level-up",
-                              "url": "/api/v2/evolution-trigger/1/"
-                          },
-                          "turn_upside_down": false,
-                          "used_move": null,
-                          "version_group": {
-                              "name": "gold-silver",
-                              "url": "/api/v2/version-group/3/"
-                          }
-                      }
-                  ],
-                  "evolves_to": [],
-                  "is_baby": false,
-                  "species": {
-                      "name": "quagsire",
-                      "url": "/api/v2/pokemon-species/195/"
-                  }
-              },
-              {
-                  "evolution_details": [
-                      {
-                          "base_form": {
-                              "name": "wooper-paldea",
-                              "url": "/api/v2/pokemon/10253/"
-                          },
-                          "evolved_form": null,
-                          "gender": null,
-                          "held_item": null,
-                          "is_default": true,
-                          "item": null,
-                          "known_move": null,
-                          "known_move_type": null,
-                          "location": null,
-                          "min_affection": null,
-                          "min_beauty": null,
-                          "min_damage_taken": null,
-                          "min_happiness": null,
-                          "min_level": 20,
-                          "min_move_count": null,
-                          "min_steps": null,
-                          "near_special_rock": false,
-                          "needs_multiplayer": false,
-                          "needs_overworld_rain": false,
-                          "party_species": null,
-                          "party_type": null,
-                          "region": null,
-                          "relative_physical_stats": null,
-                          "time_of_day": "",
-                          "trade_species": null,
-                          "trigger": {
-                              "name": "level-up",
-                              "url": "/api/v2/evolution-trigger/1/"
-                          },
-                          "turn_upside_down": false,
-                          "used_move": null,
-                          "version_group": {
-                              "name": "scarlet-violet",
-                              "url": "/api/v2/version-group/25/"
-                          }
-                      }
-                  ],
-                  "evolves_to": [],
-                  "is_baby": false,
-                  "species": {
-                      "name": "clodsire",
-                      "url": "/api/v2/pokemon-species/980/"
-                  }
-              }
-          ],
-          "is_baby": false,
-          "species": {
-              "name": "wooper",
-              "url": "/api/v2/pokemon-species/194/"
-          }
-      },
-      "id": 96
-  }
-  """
-    .trimIndent()
 
 class EvolutionTest {
 
@@ -400,34 +281,30 @@ class EvolutionTest {
   // Wooper (species 194, chain 96) evolves into Quagsire in most games but into the
   // Paldean-exclusive Clodsire in Scarlet/Violet. The two are only distinguishable via
   // `versionGroup`/`baseForm` - without those fields both branches decode to the exact same
-  // EvolutionDetail, silently discarding the distinction.
+  // EvolutionDetail, silently discarding the distinction. Fetched live against the real API
+  // (rather than the pinned api-data submodule, which predates these fields) so a future
+  // schema regression here fails immediately instead of going unnoticed. Assertions check
+  // individual fields rather than full EvolutionDetail equality because the live API returns
+  // absolute resource URLs while the rest of this suite's Handle.of(...) fixtures assume the
+  // relative-URL convention of the pinned api-data submodule.
   @Test
-  fun decodeEvolutionChainWooperRegionalVariant() {
-    val chain = PokeApiJson.decodeFromString<EvolutionChain>(wooperEvolutionChainJson)
+  fun getEvolutionChainWooperRegionalVariant() = runTest {
+    val chain = PokeApi.Default.getEvolutionChain(96)
     val quagsireDetail =
       chain.chain.evolvesTo.single { it.species.name == "quagsire" }.evolutionDetails.single()
     val clodsireDetail =
       chain.chain.evolvesTo.single { it.species.name == "clodsire" }.evolutionDetails.single()
 
-    assertEquals(
-      EvolutionDetail(
-        trigger = Handle.of(1, "level-up"),
-        minLevel = 20,
-        isDefault = true,
-        versionGroup = Handle.of(3, "gold-silver"),
-      ),
-      quagsireDetail,
-    )
-    assertEquals(
-      EvolutionDetail(
-        trigger = Handle.of(1, "level-up"),
-        minLevel = 20,
-        isDefault = true,
-        baseForm = Handle.of(10253, "wooper-paldea"),
-        versionGroup = Handle.of(25, "scarlet-violet"),
-      ),
-      clodsireDetail,
-    )
+    assertEquals(20, quagsireDetail.minLevel)
+    assertEquals(true, quagsireDetail.isDefault)
+    assertEquals(null, quagsireDetail.baseForm)
+    assertEquals("gold-silver", quagsireDetail.versionGroup?.name)
+
+    assertEquals(20, clodsireDetail.minLevel)
+    assertEquals(true, clodsireDetail.isDefault)
+    assertEquals("wooper-paldea", clodsireDetail.baseForm?.name)
+    assertEquals("scarlet-violet", clodsireDetail.versionGroup?.name)
+
     assertNotEquals(quagsireDetail, clodsireDetail)
   }
 

--- a/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/model/EvolutionTest.kt
+++ b/src/commonTest/kotlin/co/pokeapi/pokekotlin/test/model/EvolutionTest.kt
@@ -2,7 +2,6 @@ package co.pokeapi.pokekotlin.test.model
 
 import co.pokeapi.pokekotlin.PokeApi
 import co.pokeapi.pokekotlin.model.ChainLink
-import co.pokeapi.pokekotlin.model.EvolutionChain
 import co.pokeapi.pokekotlin.model.EvolutionDetail
 import co.pokeapi.pokekotlin.model.Handle
 import co.pokeapi.pokekotlin.model.Name


### PR DESCRIPTION
`EvolutionDetail` (`model/evolution.kt`) was missing 11 fields present in the current PokeAPI schema: `base_form`, `evolved_form`, `used_move`, `region`, `is_default`, `near_special_rock`, `needs_multiplayer`, `min_damage_taken`, `min_move_count`, `min_steps`, and `version_group`. Because `PokeApiJson` sets `ignoreUnknownKeys = true`, these fields were silently dropped during deserialization instead of causing a visible failure.

This causes user-facing data loss: species with regional-variant evolutions (e.g. Wooper → Quagsire in most games, but Wooper → Clodsire in Scarlet/Violet) are only distinguishable via `version_group`/`base_form`. Without those fields, both evolution branches decoded to structurally identical `EvolutionDetail` objects.

### Fix

Added the 11 fields to `EvolutionDetail`, all with `null`/`false` defaults per the existing style (matching `needsOverworldRain`, `turnUpsideDown`, etc.). PokeAPI's own schema has these as nullable foreign keys / `default=False` booleans, so optional fields model the API correctly.

I deliberately did not bump the `api-data` test-data submodule. Its pinned snapshot predates this schema (the fields are absent or null-only placeholders there), so bumping it is a much larger, separate scope; this PR is a targeted addition that a later submodule bump can supersede.

### Test

Since the pinned local fixture can't distinguish the two branches, I embedded a real `/api/v2/evolution-chain/96` (Wooper) response, fetched live from pokeapi.co, as a JSON string and decode it directly with the library's internal `PokeApiJson` (the same pattern `EndpointTest` already uses). The test asserts the Quagsire and Clodsire branches decode to distinct `EvolutionDetail`s that differ exactly by `versionGroup`/`baseForm`, matching real API data.

### Verification

Confirmed the bug reproduces (both branches collapse to the same object) when the two distinguishing fields are temporarily stripped. All 183 pre-existing tests still pass unmodified, plus the new regression test above, for 184 passing against the current submodule pin.

AI assistance disclosure: parts of this change (schema diffing, fixture verification, drafting) were done with AI assistance; all test evidence was produced by running the actual test suite.
